### PR TITLE
Update readme.en.md

### DIFF
--- a/_docs/readme.de.md
+++ b/_docs/readme.de.md
@@ -69,7 +69,7 @@ Oder das in der `.htaccess` Datei:
 
 `php_value auto_prepend_file "/user_name/public_html/phpmussel/loader.php"`
 
-7) Der Installationsvorgang wurde nun fertiggestellt. Sie sollten nun das Programm auf ordnungsgemäße Funktion testen. Sie sollten nun die im Paket enthaltenen Testdateien `_testfiles` auf Ihre Webseite über die gewöhnlichen browserbasierten Methoden hochladen. Funktioniert das Programm ordnungsgemäß, erscheint eine Meldung von phpMussel, dass der Upload erfolgreich blockiert wurde. Erscheint keine Meldung, funktioniert das Programm nicht korrekt. Nutzen Sie andere erweiterte Funktionen oder weitere mögliche Arten von Scannern dieses Programms, so sollten Sie diese ebenfalls testen, um die ordnungsgemäße Funktion sicherzustellen.
+7) Der Installationsvorgang wurde nun fertiggestellt. Sie sollten nun das Programm auf ordnungsgemäße Funktion testen. Sie sollten nun die im Paket enthaltenen Testdateien `_testfiles` auf Ihre Webseite über die gewöhnlichen browserbasierten Methoden hochladen. (Damit die Testdateien erkann werden, sollten auch die phpmussel*.db-Signaturdateien installiert und als `Active` konfiguriert sein.) Funktioniert das Programm ordnungsgemäß, erscheint eine Meldung von phpMussel, dass der Upload erfolgreich blockiert wurde. Erscheint keine Meldung, funktioniert das Programm nicht korrekt. Nutzen Sie andere erweiterte Funktionen oder weitere mögliche Arten von Scannern dieses Programms, so sollten Sie diese ebenfalls testen, um die ordnungsgemäße Funktion sicherzustellen.
 
 #### 2.1 MANUELL INSTALLIEREN (CLI - BEFEHLSZEILENMODUS)
 
@@ -538,7 +538,7 @@ Konfiguration der Signaturen.
 ##### "Active"
 - Eine Liste der aktiven Signaturdateien, die durch Kommas getrennt sind.
 
-*Hinweis: Signaturdateien müssen zuerst installiert werden, bevor Sie sie aktivieren können.*
+*Hinweis: Signaturdateien müssen zuerst installiert werden, bevor Sie sie aktivieren können. Damit die Testdateien erkannt werden, müssen die phpMussel-Signaturdateien installiert sein. Nach einer Änderung der Konfiguration, muss ggfs. der Cache geleert werden.*
 
 ##### "fail_silently"
 - Reaktion von phpMussel auf fehlende oder defekte Signaturen. Ist `fail_silently` deaktiviert, werden fehlende oder defekte Signaturen während des Scanvorgangs gemeldet, ist `fail_silently` aktiviert, werden fehlende oder defekte Signaturen ignoriert, ohne dass entsprechende Probleme gemeldet werden. Diese Option sollte so belassen werden, es sei denn, Sie erwarten Abstürze oder ähnliches. False = Deaktiviert; True = Aktiviert [Standardeinstellung].

--- a/_docs/readme.de.md
+++ b/_docs/readme.de.md
@@ -69,7 +69,7 @@ Oder das in der `.htaccess` Datei:
 
 `php_value auto_prepend_file "/user_name/public_html/phpmussel/loader.php"`
 
-7) Der Installationsvorgang wurde nun fertiggestellt. Sie sollten nun das Programm auf ordnungsgemäße Funktion testen. Sie sollten nun die im Paket enthaltenen Testdateien `_testfiles` auf Ihre Webseite über die gewöhnlichen browserbasierten Methoden hochladen. (Damit die Testdateien erkann werden, sollten auch die phpmussel*.db-Signaturdateien installiert und als `Active` konfiguriert sein.) Funktioniert das Programm ordnungsgemäß, erscheint eine Meldung von phpMussel, dass der Upload erfolgreich blockiert wurde. Erscheint keine Meldung, funktioniert das Programm nicht korrekt. Nutzen Sie andere erweiterte Funktionen oder weitere mögliche Arten von Scannern dieses Programms, so sollten Sie diese ebenfalls testen, um die ordnungsgemäße Funktion sicherzustellen.
+7) Der Installationsvorgang wurde nun fertiggestellt. Sie sollten nun das Programm auf ordnungsgemäße Funktion testen. Sie sollten nun die im Paket enthaltenen Testdateien `_testfiles` auf Ihre Webseite über die gewöhnlichen browserbasierten Methoden hochladen. (Damit die Testdateien erkannt werden, sollten auch die phpmussel*.db-Signaturdateien installiert und als `Active` konfiguriert sein.) Funktioniert das Programm ordnungsgemäß, erscheint eine Meldung von phpMussel, dass der Upload erfolgreich blockiert wurde. Erscheint keine Meldung, funktioniert das Programm nicht korrekt. Nutzen Sie andere erweiterte Funktionen oder weitere mögliche Arten von Scannern dieses Programms, so sollten Sie diese ebenfalls testen, um die ordnungsgemäße Funktion sicherzustellen.
 
 #### 2.1 MANUELL INSTALLIEREN (CLI - BEFEHLSZEILENMODUS)
 

--- a/_docs/readme.en.md
+++ b/_docs/readme.en.md
@@ -538,7 +538,7 @@ Signatures configuration.
 ##### "Active"
 - A list of the active signature files, delimited by commas.
 
-*Note: Signature files must firstly be installed, before you can activate them. For the test files to trigger, you also need to include the phpmussel signature files. After changing the configuration you may want to delete the cache.*
+*Note: Signature files must firstly be installed, before you can activate them. For the test files to trigger, you also need to include the phpMussel signature files. After changing the configuration you may want to delete the cache.*
 
 ##### "fail_silently"
 - Should phpMussel report when signatures files are missing or corrupted? If `fail_silently` is disabled, missing and corrupted files will be reported on scanning, and if `fail_silently` is enabled, missing and corrupted files will be ignored, with scanning reporting for those files that there aren't any problems. This should generally be left alone unless you're experiencing crashes or similar problems. False = Disabled; True = Enabled [Default].

--- a/_docs/readme.en.md
+++ b/_docs/readme.en.md
@@ -69,7 +69,7 @@ Or this in the `.htaccess` file:
 
 `php_value auto_prepend_file "/user_name/public_html/phpmussel/loader.php"`
 
-7) At this point, you're done! However, you should probably test it out to make sure it's working properly. To test out file upload protections, attempt to upload the testing files included in the package under `_testfiles` to your website via your usual browser-based upload methods. If everything is working, a message should appear from phpMussel confirming that the upload was successfully blocked. If nothing appears, something isn't working correctly. If you're using any advanced features or if you're using the other types of scanning possible with the tool, I'd suggest trying it out with those to make sure it works as expected, too.
+7) At this point, you're done! However, you should probably test it out to make sure it's working properly. To test out file upload protections, attempt to upload the testing files included in the package under `_testfiles` to your website via your usual browser-based upload methods. (Make sure to include the phpmussel*.db signature files in your `Active` setting for the test files to trigger.) If everything is working, a message should appear from phpMussel confirming that the upload was successfully blocked. If nothing appears, something isn't working correctly. If you're using any advanced features or if you're using the other types of scanning possible with the tool, I'd suggest trying it out with those to make sure it works as expected, too.
 
 #### 2.1 INSTALLING MANUALLY (FOR CLI)
 
@@ -538,7 +538,7 @@ Signatures configuration.
 ##### "Active"
 - A list of the active signature files, delimited by commas.
 
-*Note: Signature files must firstly be installed, before you can activate them.*
+*Note: Signature files must firstly be installed, before you can activate them. For the test files to trigger, you also need to include the phpmussel signature files. After changing the configuration you may want to delete the cache.*
 
 ##### "fail_silently"
 - Should phpMussel report when signatures files are missing or corrupted? If `fail_silently` is disabled, missing and corrupted files will be reported on scanning, and if `fail_silently` is enabled, missing and corrupted files will be ignored, with scanning reporting for those files that there aren't any problems. This should generally be left alone unless you're experiencing crashes or similar problems. False = Disabled; True = Enabled [Default].


### PR DESCRIPTION
Added a bit of information about including the `phpmussel*.db` signature files, when the engine should trigger on the test files. Also trying to explain that cache may prevent a re-scan after changing the `Active` configuration setting.

Unfortunately I can only provide a change for the English docs and not the other translations.