### PR TITLE
Add a configuration option to disable automatic scanning.

### DIFF
--- a/loader.php
+++ b/loader.php
@@ -154,7 +154,11 @@ if (!defined('phpMussel')) {
             /**
              * Check whether the upload handler exists and attempt to load it.
              */
-            if (file_exists($phpMussel['Vault'] . 'upload.php') && !$phpMussel['Alternate']) {
+            if (
+                !$phpMussel['Config']['general']['disable_autoscan'] &&
+                file_exists($phpMussel['Vault'] . 'upload.php') &&
+                !$phpMussel['Alternate']
+            ) {
                 require $phpMussel['Vault'] . 'upload.php';
             }
 

--- a/vault/config.ini.RenameMe
+++ b/vault/config.ini.RenameMe
@@ -146,6 +146,12 @@ honeypot_mode=false
 ; seconds (6 hours); A value of 0 will disable caching the results of scanning.
 scan_cache_expiry=21600
 
+; Disable automatic scanning of uploads and the automatic response pages when
+; issues were identified. When this is set to true, you will need to use the
+; Scan-function manually in a php file. False = Always scan uploaded files
+; [Default]; True = Manual scanning only.
+disable_autoscan=false
+
 ; Disable CLI mode? CLI mode is enabled by default, but can sometimes interfere
 ; with certain testing tools (such as PHPUnit, for example) and other CLI-based
 ; applications. If you don't need to disable CLI mode, you should ignore this


### PR DESCRIPTION
I've been trying to use phpMussel together with xmlhttprequest-based file uploading, which means that I would like to respond with a custom error inside a JSON response when a problem is detected.

From what I understood, it is currently not possible to disable the automatic scanning and therefore the HTML page responses that phpMussel generates when a problem is detected.

With the added `disable_autoscan` config option, the upload handler is not loaded anymore and we're free to use the Scan function when it's appropriate and generate a custom response as needed.

(Just throwing it over the fence as an idea for now. When a discussion of this proposed change looks positive I may be able to add tests later.)